### PR TITLE
Import schema to serve via github pages

### DIFF
--- a/src/analysis.xsd
+++ b/src/analysis.xsd
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="eregs"
+    xmlns:tns="eregs" 
+    elementFormDefault="qualified">
+    
+  <include schemaLocation="formatting.xsd"></include>
+
+  <!-- 
+      The analysis type describes the analysis of a section of the 
+      regulation. It consists of the following elements:
+      1. title, the title of the analysis
+      2. one or more analysisSection elements
+   -->
+  <complexType name="Analysis">
+    <sequence>
+      <choice minOccurs="0" maxOccurs="unbounded">
+        <element ref="tns:analysisSection"></element>
+      </choice>
+    </sequence>
+  </complexType>
+
+  <!-- 
+      The analysisSection describes the analysis of a section of the 
+      regulation. It consists of the following elements:
+      1. title, the title of the analysis section
+      2. one or more paragraph elements
+      3. zero or more other analysisSection elements
+   -->
+  <complexType name="AnalysisSection">
+    <sequence>
+      <element name="title" type="string"></element>
+
+      <choice minOccurs="1" maxOccurs="unbounded">
+        <element ref="tns:analysisParagraph"></element>
+        <element ref="tns:analysisSection"></element>
+      </choice>
+    </sequence>
+  </complexType>
+
+  <!-- 
+      The AnlaysisParagraph describes a paragraph within the analysis
+      of a regulation. This differs from the primitive paragraph 
+      because paragraphs within analysis are more limited in what they 
+      can express. They do not get markers, references, definitions, 
+      graphics, etc, they only contain footnotes.
+      
+      AnalysisParagraph consists of the following elements:
+
+      1. one content element, which can contain text and zero or more 
+         footnote elements
+      2. zero or more other analysisParagraph elements
+      3. zero or more footnote elements
+      4. italicized text
+   -->
+  <complexType name="AnalysisParagraph" mixed="true">
+    <sequence>
+      <choice minOccurs="0" maxOccurs="unbounded">
+        <element ref="tns:footnote"></element>
+        <element name="em" type="tns:Emphasis"></element>
+      </choice>
+    </sequence>
+  </complexType>
+
+  <!-- 
+      The footnote type defines a footnote within an analysisParagraph. 
+      Footnotes are strings with the following attributes:
+      1. reference, the reference number (typically) of the note.
+   -->
+  <complexType name="Footnote">
+    <simpleContent>
+      <extension base="string">
+        <attribute name="ref"></attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <element name="analysis" type="tns:Analysis"></element>
+  <element name="analysisSection" type="tns:AnalysisSection"></element>
+  <element name="analysisParagraph" type="tns:AnalysisParagraph"></element>
+  <element name="footnote" type="tns:Footnote"></element>
+
+</schema>

--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<include schemaLocation="primitives.xsd"></include>
+	<include schemaLocation="toc.xsd"></include>
+	
+	<!-- 
+		The appendix type defines appendices to regulation. It consists of the
+		following elements:
+		1. appendixTitle, a string giving the title of the appendix
+		2. either 0 or 1 tableOfContents elements
+		3. zero or more appendixSection elements
+		
+		In addition, the appendix element supports the following attributes:
+		1. appendixLetter, a string containing the letter by which the appendix is identified
+		2. label, a string containing an identifier by which the appendix can be referenced 
+	 -->
+	
+	<complexType name="Appendix">
+		<sequence>
+			<element name="appendixTitle" type="tns:AppendixHeader"></element>
+			<choice minOccurs="0" maxOccurs="1">
+				<element ref="tns:tableOfContents"></element>
+			</choice>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<!-- <element ref="tns:appendixHeader"></element>  -->
+				<element name="reserved" type="string"></element>
+				<element ref="tns:appendixSection"></element>
+			</choice>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+    		</choice>
+		</sequence>
+		<attribute name="appendixLetter" type="string" use="required"></attribute>
+		<attribute name="label" type="string" use="required"></attribute>
+	</complexType>
+	
+	<!-- 
+		The appendixSection type defines a section of an appendix. It consists of the
+		following elements:
+		1. subject, a string containing the section title
+		2. zero or more appendixHeader elements optionally followed by paragraph elements
+		
+		In addition the appendixSection element supports the following attributes:
+		1. appendixSecNum, an integer indicating the section number
+		2. label, a string containing a unique identifier by which the section can be referenced
+	 -->
+	
+	<complexType name="AppendixSection">
+    	<sequence>
+    		<element name="subject" type="string"></element>
+    		<choice maxOccurs="unbounded">
+    			<element ref="tns:appendixHeader"></element>
+    			<element ref="tns:paragraph"></element>
+    		</choice>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+    		</choice>
+    	</sequence>
+    	<attribute name="appendixSecNum" type="string" use="required"></attribute>
+    	<attribute name="label" type="string" use="required"></attribute>
+    </complexType>
+    
+    <!-- 
+    	The appendixHeader element is a wrapper type for a string element.
+     -->
+
+	<simpleType name="AppendixHeader">
+		<restriction base="string"></restriction>
+	</simpleType>
+	
+	<element name="appendix" type="tns:Appendix"></element>
+	<element name="tableOfContents" type="tns:TableOfContents"></element>
+	<element name="appendixSection" type="tns:AppendixSection"></element>
+    <element name="appendixHeader" type="tns:AppendixHeader"></element>
+	
+</schema>

--- a/src/eregs.xsd
+++ b/src/eregs.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<!-- 
+		This is the main file that defines the RegsML schema. It serves mostly to include
+		other files that define various parts of the schema and defines the top-level
+		regulation element.
+	 -->
+	
+	<include schemaLocation="primitives.xsd"></include>
+	<include schemaLocation="preamble.xsd"></include>
+	<include schemaLocation="toc.xsd"></include>
+	<include schemaLocation="part.xsd"></include>
+	<include schemaLocation="notices.xsd"></include>
+	
+	<!-- 
+		The regulation consists of three elements:
+		1. The FDSys tag which contains information pertinent to the federal register.
+		2. The preamble tag which contains some descriptive information about the reg.
+		3. At least one part.
+	 -->
+
+    <complexType name="Regulation">
+    	<sequence>
+    		<element name="fdsys" type="tns:FDSys"></element>
+    		<element name="preamble" type="tns:Preamble"></element>
+	    	<choice minOccurs="1" maxOccurs="unbounded">
+	    		<element ref="tns:part"></element>
+	    	</choice>
+    	</sequence>
+    </complexType>
+    
+    <!-- 
+    	The regulation element enforces the following constraints:
+    	1. IDs of definitions must be unique.
+    	2. Labels of paragraphs must be unique.
+    	3. Labels of sections must be unique.
+    	4. Labels of subparts must be unique.
+    	5. Labels of appendices must be unique.
+    	6. Labels of appendix sections must be unique.
+     -->
+
+    <element name="regulation" type="tns:Regulation">
+    	<unique name="unique-def-id">
+    		<selector xpath=".//tns:def"></selector>
+    		<field xpath="@def-id"></field>
+    	</unique>
+    	<unique name="unique-par-label">
+    		<selector xpath=".//tns:paragraph|.//tns:section|.//tns:subpart|.//tns:appendix|.//tns:appendixSection"></selector>
+    		<field xpath="@label"></field>
+    	</unique>
+    	<unique name="unique-interp-label">
+    		<selector xpath=".//tns:interpSection|.//tns:interpParagraph|.//interpAppSection"></selector>
+    		<field xpath="@label"></field>
+    	</unique>
+    </element>
+        
+</schema>

--- a/src/formatting.xsd
+++ b/src/formatting.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+
+	<!--  
+	The Emphasis type describes italicized text. It is an extension of string, having the additional
+	attribute of data-original, which describes the original emphasis tag from the eCFR XML.
+	 -->
+	
+	<complexType name="Emphasis">
+		<simpleContent>
+			<extension base="string">
+				<attribute name="data-original" type="string"></attribute>
+			</extension>
+		</simpleContent>
+	</complexType>
+	
+	<element name="em"></element>
+	<element name="dash"></element>
+	
+</schema>

--- a/src/interpretation.xsd
+++ b/src/interpretation.xsd
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<include schemaLocation="primitives.xsd"></include>
+	<include schemaLocation="appendix.xsd"></include>
+	<include schemaLocation="toc.xsd"></include>
+	
+	<complexType name="Interpretations">
+		<sequence>
+			<element name="title" type="string"></element>
+			<sequence>
+	    		<choice minOccurs="0" maxOccurs="unbounded">
+	    			<element ref="tns:interpSection"></element>
+	    		</choice>
+	    		<choice minOccurs="0" maxOccurs="unbounded">
+	    			<element ref="tns:interpAppSection"></element>
+	    		</choice>
+    		</sequence>
+<!-- 			<choice minOccurs="0" maxOccurs="1"> -->
+<!-- 				<element name="content" type="tns:InterpContents"></element> -->
+<!-- 			</choice> -->
+		</sequence>
+		<attribute name="label" type="string"></attribute>
+	</complexType>
+	
+	<complexType name="InterpSection">
+		<sequence>
+			<choice minOccurs="0" maxOccurs="1">
+				<element name="title" type="string"></element>
+			</choice>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element ref="tns:interpHeader"></element>
+			</choice>
+			<choice maxOccurs="unbounded">
+				<element name="reserved" type="string"></element>
+    			<element ref="tns:interpParagraph"></element>
+			</choice>
+            <choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+            </choice>
+		</sequence>
+		<attribute name="sectionNum" type="int" use="optional"></attribute>
+    	<attribute name="label" type="string" use="required"></attribute>
+	</complexType>
+	
+	<complexType name="InterpAppSection">
+		<sequence>
+			<choice minOccurs="0" maxOccurs="1">
+				<element name="title" type="string"></element>
+			</choice>
+			<choice maxOccurs="unbounded">
+				<element name="reserved" type="string"></element>
+    			<element ref="tns:interpParagraph"></element>
+			</choice>
+            <choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+            </choice>
+		</sequence>
+		<attribute name="appendixSecNum" type="int" use="required"></attribute>
+    	<attribute name="label" type="string" use="required"></attribute>
+	</complexType>
+	
+	<complexType name="InterpAppendix">
+		<sequence>
+			<element name="title" type="string"></element>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element ref="tns:interpAppSection"></element>
+				<element ref="tns:interpParagraph"></element>
+    			<element ref="tns:analysis"></element>
+			</choice>
+		</sequence>
+		<attribute name="appendixLetter" type="string" use="required"></attribute>
+		<attribute name="label" type="string" use="required"></attribute>
+	</complexType>
+	
+	<complexType name="InterpContents">
+    	<sequence>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:interpSection"></element>
+    		</choice>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+                <element ref="tns:interpAppendix"></element>
+    		</choice>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+    		</choice>
+    	</sequence>
+    </complexType>
+    
+    <complexType name="InterpParagraph">
+    	<sequence>
+    		<choice minOccurs="0" maxOccurs="1">
+    			<element name="title" type="string"></element>
+    		</choice>
+    		<element name="content" type="tns:RegText"></element>
+    		<element ref="tns:interpParagraph" minOccurs="0" maxOccurs="unbounded"></element>
+            <choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+            </choice>
+    	</sequence>
+		<attribute name="marker" type="string" use="optional"></attribute>
+		<attribute name="label" type="string" use="required"></attribute>
+		<attribute name="target" type="string" use="optional"></attribute>
+    </complexType>
+    
+    <simpleType name="InterpHeader">
+		<restriction base="string"></restriction>
+	</simpleType>
+	
+	<element name="interpretations" type="tns:Interpretations"></element>
+	<element name="interpAppendix" type="tns:InterpAppendix"></element>
+	<element name="interpSection" type="tns:InterpSection"></element>
+	<element name="interpAppSection" type="tns:InterpAppSection"></element>
+	<element name="interpContent" type="tns:InterpContents"></element>
+	<element name="interpParagraph" type="tns:InterpParagraph"></element>
+	<element name="interpHeader" type="tns:InterpHeader"></element>
+	
+</schema>

--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="eregs"
+    xmlns:tns="eregs" 
+    elementFormDefault="qualified">
+
+  <include schemaLocation="primitives.xsd"></include>
+  <include schemaLocation="preamble.xsd"></include>
+  <include schemaLocation="toc.xsd"></include>
+  <include schemaLocation="part.xsd"></include>
+
+  <!-- 
+       Notices include the same sorts of content as regulations do,
+       except that the content is just the things that have been 
+       modified from the last notice, wrapped in a changeset element. 
+       
+      All the notice metadata is contained within the preamble, which 
+      is identical to the regulation preamble.
+  -->
+  <complexType name="Notice">
+    <sequence>
+      <element ref="tns:fdsys"></element>
+      <element ref="tns:preamble"></element>
+      <choice minOccurs="0" maxOccurs="1">
+        <element ref="tns:changeset"></element>
+      </choice>
+    </sequence>
+  </complexType>
+
+  <!-- 
+      Changeset express changes from one version of a regulation to
+      another. This includes operations that add/modify/delete for a 
+      given label within the regulation itself. It consists of the 
+      following elements:
+
+      1. leftDocumentNumber, the notice document number of the left 
+         version, which will be transformed into the right.
+      2. rightDocumentNumber, the notice document number of the right 
+         version, the one into which the left is transformed.
+   -->
+  <complexType name="Changeset">
+    <sequence>
+      <choice minOccurs="0" maxOccurs="unbounded">
+        <element ref="tns:change"></element>
+      </choice>
+    </sequence>
+    <attribute name="leftDocumentNumber" type="string"></attribute>
+    <attribute name="rightDocumentNumber" type="string"></attribute>
+  </complexType>
+
+  <!-- 
+       A Change modifies the given label from the immediately prior 
+       version of a regulation with the given contents. Deletions won't 
+       have any content.
+
+       "operation" should be one of "added", "modified", or "deleted".
+   -->
+  <complexType name="Change">
+    <choice minOccurs="0" maxOccurs="unbounded">
+      <element name="reserved" type="string"></element>
+      <element ref="tns:section"></element>
+      <element ref="tns:paragraph"></element>
+      <element ref="tns:analysis"></element>
+      <element ref="tns:appendix"></element>
+      <element ref="tns:appendixSection"></element>
+      <element ref="tns:interpParagraph"></element>
+      <element ref="tns:interpretations"></element>
+      <element ref="tns:interpSection"></element>
+    </choice>
+    <attribute name="operation">
+      <simpleType>
+        <restriction base="string">
+          <enumeration value="added"/>
+          <enumeration value="modified"/>
+          <enumeration value="deleted"/>
+        </restriction>
+      </simpleType>
+    </attribute>
+    <attribute name="label"></attribute>
+  </complexType>
+
+  <element name="change" type="tns:Change"></element>
+  <element name="changeset" type="tns:Changeset"></element>
+  <element name="notice" type="tns:Notice"></element>
+</schema>

--- a/src/part.xsd
+++ b/src/part.xsd
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<include schemaLocation="primitives.xsd"></include>
+	<include schemaLocation="appendix.xsd"></include>
+	<include schemaLocation="toc.xsd"></include>
+	<include schemaLocation="interpretation.xsd"></include>
+	
+	<!-- 
+		The section element describes the contents of a section of regulation.
+		It consists of the following elements:
+		1. subject, a string containing the title of the section
+		2. zero or more paragraph elements
+		
+		The section element supports the following attributes:
+		1. sectionNum, an integer indicating the section number
+		2. label, a unique id by which the section can be referenced
+	 -->
+	
+	<complexType name="Section">
+    	<sequence>
+    		<element name="subject" type="string"></element>
+    		<choice maxOccurs="unbounded">
+    			<element name="reserved" type="string"></element>
+    			<element name="paragraph" type="tns:Paragraph"></element>
+    			<element ref="tns:analysis"></element>
+    		</choice>
+    	</sequence>
+    	<attribute name="sectionNum" type="int" use="required"></attribute>
+    	<attribute name="label" type="string" use="required"></attribute>
+    </complexType>
+    
+    <!-- 
+    	The partContents type defines the contents of a part of a regulation.
+    	It consists of the following elements:
+    	1. zero or one auth elements. The auth element is a complex type consisting
+    	   of the following elements:
+    		a. title, a string indicating issuing authority
+    		b. content, a string indicating where the issuing authority comes from
+    	2. zero or more section elements
+    	3. zero or more appendix elements
+     -->
+    
+    <complexType name="PartContents">
+    	<sequence>
+			<choice minOccurs="0" maxOccurs="1">
+				<element name="auth">
+					<complexType>
+						<sequence>
+							<element name="title" type="string"></element>
+							<element name="content" type="string"></element>
+						</sequence>
+					</complexType>
+				</element>
+			</choice>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element ref="tns:section"></element>
+			</choice>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element ref="tns:appendix"></element>
+			</choice>
+		</sequence>
+    </complexType>
+   
+    
+    <!-- 
+    	The subpart type describes a subpart to a regulation.
+    	It consists of the following elements:
+    	1. zero or one title elements, a string giving the subpart title
+    	2. zero or one tableOfContent elements, which describe the table of contents in the subpart
+    	3. at least one partContents elements.
+    	
+    	In addition, subpart contains the following attributes:
+    	1. subpartLetter, a string identifying the letter of this subpart
+     -->
+    
+    <complexType name="Subpart">
+    	<sequence>
+    		<choice minOccurs="0" maxOccurs="1">
+    			<element name="title" type="string"></element>
+    		</choice>
+    		<choice minOccurs="0" maxOccurs="1">
+    			<element name="tableOfContents" type="tns:TableOfContents"></element>
+    		</choice>
+    		<choice minOccurs="1" maxOccurs="unbounded">
+    			<element name="content" type="tns:PartContents"></element>
+    		</choice>
+    	</sequence>
+    	<attribute name="subpartLetter" type="string"></attribute>
+    </complexType>
+    
+    <!-- 
+    	The part element describes the part of a regulation.
+    	It consists of the following elements:
+    	1. zero or one tableOfContents elements that describe the table of contents within the part
+    	2. content, an element which consists of the following sub-elements:
+    		a. zero or more subpart elements
+    		b. zero or more appendix elements
+    		c. zero or more interpretation elements
+     -->
+	
+	<complexType name="Part">	
+		<sequence>
+			<choice minOccurs="0" maxOccurs="1">
+				<element name="tableOfContents" type="tns:TableOfContents"></element>
+			</choice>
+			<element name="content">
+				<complexType>
+					<sequence>	
+						<choice minOccurs="0" maxOccurs="unbounded">
+							<element ref="tns:subpart"></element>
+							<element ref="tns:appendix"></element>
+							<element ref="tns:interpretations"></element>
+						</choice>
+					</sequence>	
+				</complexType>
+			</element>
+		</sequence>
+		<attribute name="label" type="int" use="required"></attribute>
+	</complexType>
+	
+	<element name="section" type="tns:Section"></element>
+	<element name="subpart" type="tns:Subpart"></element>
+	<element name="part" type="tns:Part"></element>
+	
+	
+</schema>

--- a/src/preamble.xsd
+++ b/src/preamble.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<!-- 
+		The preamble to a regulation contains descriptive information about the regulation.
+		It consists of the following elements:
+		1. agency, a string that identifies the agency which issued the regulation
+		2. cfr, a complex element that supports the following sub-elements:
+		 a. title, an integer identifying the CFR title containing the regulation
+		 b. section, an integer identifying the CFR section containing the regulation
+		3. effectiveDate, the date on which the regulation takes effect
+        4. federalRegisterURL, the human-friendly URL to the notice in the Federal Register
+	 -->
+	
+	<complexType name="Preamble">
+		<sequence>
+			<element name="agency" type="string"></element>
+			<element name="cfr">
+				<complexType>
+					<sequence>
+						<element name="title" type="int"></element>
+						<element name="section" type="int"></element>
+					</sequence>
+				</complexType>
+			</element>
+			<element name="documentNumber" type="string"></element>
+<!-- 			<element name="depdoc" type="string"></element> -->
+<!-- 			<element name="rin" type="string"></element> -->
+<!-- 			<element name="summary"> -->
+<!-- 				<complexType> -->
+<!-- 					<sequence> -->
+<!-- 						<element name="header" type="string"></element> -->
+<!-- 						<element name="content" type="string"></element> -->
+<!-- 					</sequence> -->
+<!-- 				</complexType> -->
+<!-- 			</element> -->
+			<element name="effectiveDate" type="date"></element>
+			<element name="federalRegisterURL" type="string"></element>
+		</sequence>
+	</complexType>
+	
+	<!-- 
+		
+	 -->
+	
+	<complexType name="FDSys">
+		<sequence>
+			<element name="cfrTitleNum" type="int"></element>
+			<element name="cfrTitleText" type="string"></element>
+			<element name="volume" type="int"></element>
+			<element name="date" type="date"></element>
+			<element name="originalDate" type="date"></element>
+			<element name="title" type="string"></element>
+		</sequence>
+	</complexType>
+	
+	<element name="preamble" type="tns:Preamble"></element>
+	<element name="fdsys" type="tns:FDSys"></element>
+</schema>

--- a/src/primitives.xsd
+++ b/src/primitives.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<include schemaLocation="table.xsd"></include>
+	<include schemaLocation="formatting.xsd"></include>
+	<include schemaLocation="analysis.xsd"></include>
+	
+	<!-- 
+		This file represents the primitives that are allowed in the RegsML.
+	 -->
+	
+	<!-- 
+		Regulation text is a mixed element that can contain:
+		1. Regular text, 
+		2. references, and
+		3. definitions.
+	 -->
+	
+	<complexType name="RegText" mixed="true">
+		<choice minOccurs="0" maxOccurs="unbounded">
+			<element ref="tns:ref"></element>
+			<element ref="tns:def"></element>
+			<element ref="tns:graphic"></element>
+			<element ref="tns:dash"></element>
+			<element ref="tns:table"></element>
+			<element ref="tns:analysis"></element>
+		</choice>
+	</complexType>
+	
+	<!-- 
+		titleType enumerates the possible attributes that can be contained
+		in a paragraph title tag
+	 -->
+	
+	<simpleType name="titleType">
+		<restriction base="string">
+			<enumeration value="header"></enumeration>
+			<enumeration value="keyterm"></enumeration>
+		</restriction>
+	</simpleType>
+	
+	<!-- 
+		The paragraph element can contain the following:
+		1. At most 1 paragraph title.
+		   a. Which supports a type attribute indicating whether the title is a keyterm
+		2. One content tag that contains regtext.
+		3. Possibly any number of subparagraphs.
+		
+		In addition, the paragraph element contains the following attributes:
+		1. marker, which defines the marker that is placed in the beginning of the paragraph
+		2. label, which defines the unique tag that identifies the paragraph.
+	 -->
+	
+	<complexType name="Paragraph">
+    	<sequence>
+    		<choice minOccurs="0" maxOccurs="1">
+    			<element name="title">
+    				<complexType>
+    					<simpleContent>
+    						<extension base="string">
+    							<attribute name="type" type="tns:titleType"></attribute>
+    						</extension>
+    					</simpleContent>
+    				</complexType>
+    			</element>
+    		</choice>
+    		<element name="content" type="tns:RegText"></element>
+    		<element ref="tns:paragraph" minOccurs="0" maxOccurs="unbounded"></element>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+    			<element ref="tns:analysis"></element>
+    		</choice>
+    	</sequence>
+		<attribute name="marker" type="string" use="required"></attribute>
+		<attribute name="label" type="string"></attribute>
+    </complexType>
+
+	<!-- 
+		The reference element supports referencing any other element with a label attribute.
+		The reference element has the following attributes:
+		1. target, the element being referenced.
+		2. reftype, the type of reference (internal or external)
+	 -->
+	 
+	<simpleType name="reftype">
+		<restriction base="string">
+			<enumeration value="internal"></enumeration>
+			<enumeration value="external"></enumeration>
+			<enumeration value="footnote"></enumeration>
+			<enumeration value="term"></enumeration>
+		</restriction>
+	</simpleType>
+
+	<complexType name="Reference">
+		<simpleContent>
+			<extension base="string">
+				<attribute name="target" type="string"></attribute>
+				<attribute name="reftype" type="tns:reftype"></attribute>
+			</extension>
+		</simpleContent>
+	</complexType>
+	
+	<!-- 
+		The definition element supports defined terms within the text.
+		The defintion has the following attributes:
+		1. id, a unique id
+		2. term, the actual term being defined within this tag
+	 -->
+	
+	<complexType name="Definition">
+		<simpleContent>
+			<extension base="string">
+				<attribute name="id" type="string" use="optional"></attribute>
+				<attribute name="term" type="string" use="required"></attribute>
+			</extension>
+		</simpleContent>
+	</complexType>
+	
+	<!--  
+		The graphics element supports embedding graphics within the text.
+		
+	 -->
+	
+	<complexType name="Graphics">
+		<sequence>
+			<element name="altText" type="string"></element>
+			<element name="text" type="string"></element>
+			<element name="url" type="anyURI"></element>
+			<choice minOccurs="0" maxOccurs="1">
+				<element name="thumbUrl" type="anyURI"></element>
+			</choice>
+		</sequence>
+	</complexType>
+	
+	<!-- 
+		Elements instantiating the various types.
+	 -->
+	
+	<element name="ref" type="tns:Reference"></element>
+    <element name="paragraph" type="tns:Paragraph"></element>
+    <element name="def" type="tns:Definition"></element>
+    <element name="graphic" type="tns:Graphics"></element>
+    
+</schema>

--- a/src/reg_d_sample.xml
+++ b/src/reg_d_sample.xml
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="eregs eregs.xsd">
+	<fdsys>
+		<cfrTitleNum>12</cfrTitleNum>
+		<cfrTitleText>Banks and Banking</cfrTitleText>
+		<volume>8</volume>
+		<date>2012-01-01</date>
+		<originalDate>2012-01-01</originalDate>
+		<title>ALTERNATIVE MORTGAGE TRANSACTION PARITY (REGULATION D)</title>
+	</fdsys>
+	<preamble>
+		<agency>Consumer Financial Protection Bureau</agency>
+		<cfr>
+			<title>12</title>
+			<section>1004</section>
+		</cfr>
+		<depdoc>[Docket No. CFPB-2011-0004]</depdoc>
+		<rin>RIN 3170-AA04</rin>
+		<summary>
+			<header>SUMMARY:</header>
+			<content>
+				The Bureau of Consumer Financial Protection (CFPB) is publishing for public comment 
+				an interim final rule establishing Regulation D (Alternative Mortgage Transaction Parity) pursuant to the Alternative Mortgage Transaction Parity Act (AMTPA) and the Truth in Lending Act. The interim final rule is necessary to avoid a regulatory gap created by the amendments to AMTPA in the Dodd-Frank Wall Street Reform and Consumer Protection Act (Dodd-Frank Act). Without an interim final rule that takes immediate effect, state housing creditors would no longer be able to make variable rate mortgage loans and other alternative mortgage transactions pursuant to AMTPA in states that prohibit such transactions, thus denying consumers access to that form of credit. Until July 22, 2012, the interim final rule applies only to state housing creditors seeking to invoke federal preemption of state law under AMTPA. The interim final rule will be in place as a temporary measure pending the CFPB's completion of a notice-and-comment rulemaking to promulgate permanent rules, including rules governing alternative mortgage transactions made by federally chartered housing creditors. The CFPB seeks public comment in anticipation of that process.
+			</content>
+		</summary>
+		<effectiveDate>2011-07-22</effectiveDate>
+	</preamble>
+	<part partNumber="1004">
+		<content>
+			<tableOfContents>
+				<tocSecEntry>
+					<sectionNum>1</sectionNum>
+					<sectionSubject>Authority, purpose, and scope.</sectionSubject>
+				</tocSecEntry>
+				<tocSecEntry>
+					<sectionNum>2</sectionNum>
+	      			<sectionSubject>Definitions.</sectionSubject>
+				</tocSecEntry>
+				<tocSecEntry>
+					<sectionNum>3</sectionNum>
+					<sectionSubject>Preemption of State law.</sectionSubject>
+				</tocSecEntry>
+				<tocSecEntry>
+					<sectionNum>4</sectionNum>
+					<sectionSubject>Requirements for alternative mortgage transactions.</sectionSubject>
+				</tocSecEntry>
+				<tocAppEntry>
+					<appendixLetter>A</appendixLetter>
+					<appendixSubject>Appendix A to Part 1004—Official Commentary on Regulation D</appendixSubject>
+				</tocAppEntry>
+			</tableOfContents>
+			<auth>
+				<title>Authority:</title>
+				<content>12 U.S.C. 3802, 3803; 15 U.S.C. 1604, 1639b; Pub. L. No. 111-203, 124 Stat. 1376.</content>
+			</auth>
+			<section sectionNum="1">
+				<subject>Authority, purpose, and scope.</subject>
+				<paragraph marker="a">
+				 	<title>Authority.</title>
+				 	<content>
+				 		This regulation, known as Regulation D, is issued by the Bureau of Consumer Financial Protection to implement the Alternative Mortgage Transaction Parity Act, 12 U.S.C. 3801 et seq., as amended by title X, Section 1083 of the Dodd-Frank Wall Street Reform and Consumer Protection Act (Pub. L. 111-203, 124 Stat. 1376). Section 1004.4 is issued pursuant to the Alternative Mortgage Transaction Parity Act (as amended) and the Truth in Lending Act, 15 U.S.C. 1601 et seq.
+				 	</content>
+			 	</paragraph>
+		   		<paragraph marker="b">
+		   			<title>Purpose.</title>
+		   			<content>
+		   				Consistent with the Alternative Mortgage Transaction Parity Act, the Truth in Lending Act, and the Dodd-Frank Wall Street Reform and Consumer Protection Act, the purpose of this regulation is to balance access to responsible credit and enhanced parity between State and federal housing creditors regarding the making, purchase, and enforcement of alternative mortgage transactions with consumer protection and the interests of the States in regulating mortgage transactions generally.
+		   			</content>
+		   		</paragraph>
+				<paragraph marker="c">
+					<title>Scope.</title>
+					<content>
+						This regulation applies to an alternative mortgage transaction if the creditor received an application for that transaction on or after July 22, 2011. This regulation does not apply to a transaction if the creditor received the application for that transaction before July 22, 2011.
+					</content>
+				</paragraph>
+			</section>
+				<section sectionNum="2">
+	      		<subject>Definitions.</subject>
+	      		<paragraph marker="none">
+	      			<content>
+	      				For purposes of this part:
+	      			</content>
+	      			<paragraph marker="a">
+	    				<content>
+	    					<def>Alternative mortgage transaction</def> means a loan, credit sale, or account:
+	    				</content>
+	    				<paragraph marker="1">
+	    					<content>
+	    						 That is secured by an interest in a residential structure that contains one to four units, whether or not that structure is attached to real property, including an individual condominium unit, cooperative unit, mobile home, or trailer, if it is used as a residence;
+	    					</content>
+	    				</paragraph>
+	    				<paragraph marker="2">
+	    					<content>
+	    						That is made primarily for personal, family, or household purposes; and
+	    					</content>
+	    				</paragraph>
+	    				<paragraph marker="3">
+	    					<content>
+	    						In which the interest rate or finance charge may be adjusted or renegotiated.
+	    					</content>
+	    				</paragraph>    				
+	    			</paragraph>
+	    			<paragraph marker="b">
+	    				<content>
+	    					<def>Creditor</def> shall have the same meaning as in <ref>12 CFR 226.2</ref>.
+	    				</content>
+	    			</paragraph>
+	    			<paragraph marker="c" label="1004-2-c-1">
+	    				<content>
+	    					<def>Housing creditor</def> means:
+	    				</content>
+	    				<paragraph marker="1" label="1004-2-c-2">
+	    					<content>
+	    						A depository institution, as defined in section 501(a)(2) of the Depository Institutions Deregulation and Monetary Control Act of 1980;
+	    					</content>
+	    				</paragraph>
+	    				<paragraph marker="2">
+	    					<content>
+	    						A lender approved by the Secretary of Housing and Urban Development for participation in any mortgage insurance program under the National Housing Act;
+	    					</content>
+	    				</paragraph>
+	    				<paragraph marker="3">
+	    					<content>
+	    						Any person who regularly makes loans, credit sales, or advances on an account secured by an interest in a residential structure that contains one to four units, whether or not the structure is attached to real property, including an individual condominium unit, cooperative unit, mobile home, or trailer, if it is used as a residence; and
+	    					</content>
+	    				</paragraph>
+	    				<paragraph marker="4">
+	    					<content>
+	    						Any transferee of a party listed in paragraph <ref target="1004-2-c-1">(c)(1)</ref>, <ref target="1004-2-c-2">(2)</ref>, or <ref target="1004-2-c-3">(3)</ref> of this section.
+	    					</content>
+	    				</paragraph>
+	    			</paragraph>
+	    			<paragraph marker="d">
+	    				<content>
+	    					<def>State</def> means any State of the United States of America, the District of Columbia, Puerto Rico, the Virgin Islands, the Northern Mariana Islands, American Samoa, Guam, and any other territory or possession of the United States.
+	    				</content>
+	    			</paragraph>
+	    			<paragraph marker="e">
+	    				<content>
+	    					<def>State law</def> means a State constitution, statute, or regulation or any provision thereof.
+	    				</content>
+	    			</paragraph>
+	      		</paragraph>
+	   		</section>
+	   		<section sectionNum="3">
+	   			<subject>Preemption of State law.</subject>
+	   			<paragraph marker="none">
+	   				<content>
+	   					Pursuant to 12 U.S.C. 3803, a State-chartered or -licensed housing creditor may make, purchase, and enforce alternative mortgage transactions in accordance with § 1004.4(a) through (c) of this part (as applicable), notwithstanding any provision of State law that restricts the ability of the housing creditor to adjust or renegotiate an interest rate or finance charge with respect to the transaction or to change the amount of interest or finance charges included in a regular periodic payment as a result of such an adjustment or renegotiation.
+	   				</content>
+	   			</paragraph>
+	   		</section>
+	   		<section sectionNum="4">
+	   			<subject>Requirements for alternative mortgage transactions.</subject>
+	   			<paragraph marker="a">
+	   				<title>Mortgages with adjustable rates or finance charges and home equity lines of credit.</title>
+	   				<content>
+	   					A creditor that makes an alternative mortgage transaction with an adjustable rate or finance charge may only increase the interest rate or finance charge as follows:
+	   				</content>
+	   				<paragraph marker="1">
+	   					<content>
+	   					If the transaction is subject to <ref>12 CFR 226.5b</ref>, the creditor must comply with <ref>12 CFR 226.5b(f)(1).</ref>
+	   				</content>
+	   				</paragraph>
+	   				<paragraph marker="2">
+	   					<content>For all other transactions, the creditor must use either:</content>
+	   					<paragraph marker="i">
+	   						<content>
+	   							An index to which changes in the interest rate are tied that is readily available to and verifiable by the borrower and beyond the control of the creditor; or
+	   						</content>
+	   					</paragraph>
+	   					<paragraph marker="ii">
+	   						<content>
+	   							A formula or schedule identifying the amount that the interest rate or finance charge may increase and the times at which, or circumstances under which, a change may be made.
+	   						</content>
+	   					</paragraph>
+	   				</paragraph>
+	      		</paragraph>
+	      		<paragraph marker="b">
+	      			<title>Renegotiable rates for renewable balloon-payment mortgages.</title>
+	      			<content>
+	      				A creditor that makes an alternative mortgage transaction with payments based on an amortization period and a large final payment due after a shorter term may negotiate an increase or decrease in the interest rate when the transaction is renewed only if the creditor makes a written commitment to renew the transaction at specified intervals throughout the amortization period. However, the creditor is not required to renew the transaction if:
+	      			</content>
+	      			<paragraph marker="1">
+	      				<content>
+	      					Any action or inaction by the consumer materially and adversely affects the creditor's security for the transaction or any right of the creditor in such security;
+	      				</content>
+	      			</paragraph>
+	      			<paragraph marker="2">
+	      				<content>
+	      					There is a material failure by the consumer to meet the repayment terms of the transaction;
+	      				</content>
+	      			</paragraph>
+	      			<paragraph marker="3">
+	      				<content>
+	      					There is fraud or a willful or knowing material misrepresentation by the consumer in connection with the transaction; or
+	      				</content>
+	      			</paragraph>
+	      			<paragraph marker="4">
+	      				<content>
+	      					Federal law dealing with credit extended by a depository institution to its executive officers specifically requires that as a condition of the extension the credit shall become due and payable on demand, provided that the creditor includes such a provision in the initial agreement.
+	      				</content>
+	      			</paragraph>
+	      		</paragraph>
+	      		<paragraph marker="c">
+	      			<title>Requirements for high-cost and higher-priced mortgage loans.</title>
+	      			<content></content>
+	      			<paragraph marker="1">
+	      				<content>
+	      					If an alternative mortgage transaction is subject to <ref>12 CFR 226.32</ref>, the creditor must comply with <ref>12 CFR 226.32</ref> and <ref>12 CFR 226.34</ref>.
+	      				</content>
+	      			</paragraph>
+	      			<paragraph marker="2">
+	      				<content>
+	      					If an alternative mortgage transaction is subject to <ref>12 CFR 226.35</ref>, the creditor must comply with <ref>12 CFR 226.35</ref>.
+	      				</content>
+	      			</paragraph>
+	      		</paragraph>
+	      		<paragraph marker="d">
+	      			<title>Other applicable law.</title>
+	      			<content>
+	      				Notwithstanding paragraphs <ref target="1004-4-a">(a)</ref> through <ref target="1004-4-c">(c)</ref> of this section, a housing creditor that is not making an alternative mortgage transaction pursuant to § 1004.3 of this part may make that transaction consistent with applicable State or Federal law other than this section.
+	      			</content>
+	      		</paragraph>
+	      		<paragraph marker="e">
+	      			<title>Reductions in interest rate or finance charge.</title>
+	      			<content>
+	      				Nothing in this section prohibits a creditor from decreasing the interest rate or finance charge on an alternative mortgage transaction.
+	      			</content>
+	      		</paragraph>
+	   		</section>
+	   		<appendix appendixLetter="A" label="1004-A">
+	   			<appendixTitle>Appendix A to Part 1004—Official Commentary on Regulation D</appendixTitle>
+	   			<appendixSection appendixSecNum="1" label="1004-A-1">	
+	   				<subject>§ 1004.1 Authority, Purpose, and Scope</subject>
+	   				<appendixHeader>1(c) Scope</appendixHeader>
+	   				<paragraph marker="1">
+	   					<title>Application received before July 22, 2011.</title>
+	   					<content>
+	   						This Part does not apply to a transaction if the creditor received the application for that transaction before July 22, 2011, even if the transaction was consummated or completed on or after July 22, 2011. Whether 12 U.S.C. 3803(c) preempts State law with respect to such a transaction depends on whether: (1) The transaction was an alternative mortgage transaction as defined by the version of 12 U.S.C. 3802(1) in effect at the time of application; and (2) the State housing creditor complied with applicable federal regulations issued by the Office of the Comptroller of the Currency, the National Credit Union Administration, the Office of Thrift Supervision, or the Federal Home Loan Bank Board in effect at the time of application.
+	   					</content>
+	   				</paragraph>
+	   				<paragraph marker="2">
+	   					<title>Subsequent modifications and other actions.</title>
+	   					<content>
+	   						If applicable regulations under 12 U.S.C. 3803(c) (including this Part) preempted State law with respect to an alternative mortgage transaction at the time the application was received, the following actions with respect to that transaction are entitled to the same degree of preemption under such regulations:
+	   					</content>
+	   					<paragraph marker="i">
+	   						<content>
+	   							The subsequent consummation, completion, purchase, or enforcement of the transaction by a housing creditor.
+	   						</content>
+	   					</paragraph>
+	   					<paragraph marker="ii">
+	   						<content>
+	   							 The subsequent modification, renewal, or extension of the transaction. However, if such a transaction is satisfied and replaced by another transaction, the second transaction must independently meet the requirements for preemption in effect at the time the application for the second transaction was received.
+	   						</content>
+	   					</paragraph>
+	   				</paragraph>
+	   			</appendixSection>
+	   			<appendixSection appendixSecNum="2" label="1004-A-2">
+	   				<subject>§ 1004.2 Definitions</subject>
+	   				<appendixHeader>2(a) Alternative Mortgage Transaction</appendixHeader>
+	   				 <paragraph marker="1">
+	   				 	<title>Alternative mortgage transaction.</title>
+	   				 	<content>
+	   				 		For purposes of this Part, an alternative mortgage transaction that meets the definition in § 1004.2(a) includes any consumer credit transaction that is secured by a mortgage, deed of trust, or other equivalent consensual security interest in a dwelling or in residential real property that includes a dwelling. The dwelling need not be the primary dwelling of the consumer. Home equity lines of credit and subordinate lien mortgages are alternative mortgage transactions for purposes of this Part to the extent they meet the definition in § 1004.2(a).
+	   				 	</content>
+	   				</paragraph>
+	      			<paragraph marker="2">
+	      				<title>Examples of alternative mortgage transactions.</title>
+	      				<content>
+	      					Examples of alternative mortgage transactions include:
+	      				</content>
+	      				<paragraph marker="i">
+	      					<content>
+	      						Transactions in which the interest rate changes in accordance with fluctuations in an index.
+	      					</content>
+	      				</paragraph>
+	      				<paragraph marker="ii">
+	      					<content>
+	      						Transactions in which the interest rate or finance charge may be increased or decreased after a specified period of time or under specified circumstances.
+	      					</content>
+	      				</paragraph>
+	      				<paragraph marker="iii">
+	      					<content>
+	      						Balloon transactions in which payments are based on an amortization schedule and a large final payment is due after a shorter term, where the creditor makes a commitment to renew the transaction at specified intervals throughout the amortization period, but the interest rate may be renegotiated at renewal. For example, a fixed-rate mortgage loan with a 30-year amortization period but a balloon payment due five years after consummation is an alternative mortgage transaction under § 1004.2(a) if the creditor commits to renew the mortgage at five-year intervals for the entire 30-year amortization period.
+	      					</content>
+	      				</paragraph>
+	      				<paragraph marker="iv">
+	      					<content>
+	      						Transactions in which the creditor and the consumer agree to share some or all of the appreciation in the value of the property (shared equity/shared appreciation).
+	      					</content>
+	      				</paragraph>
+	      				<paragraph marker="none">
+	      					<content>
+	      						However, this Part preempts State law only to the extent provided in § 1004.3 and only to the extent that the requirements of § 1004.4(a) through (c) (as applicable) are met.
+	      					</content>
+	      				</paragraph>
+	      			</paragraph>
+	      			<paragraph marker="3">
+	      				<title>Examples of transactions that are not alternative mortgage transactions.</title>
+	      				<content>
+	      					The following are examples of transactions that are not alternative mortgage transactions:
+	      				</content>
+	      				<paragraph marker="i">
+	      					<content>
+	      						Transactions with a fixed interest rate where one or more of the regular periodic payments may be applied solely to accrued interest and not to loan principal (an interest-only feature).
+	      					</content>
+	      				</paragraph>
+	      				<paragraph marker="ii">
+	      					<content>
+	      						Balloon transactions with a fixed interest rate where payments are based on an amortization schedule and a large final payment is due after a shorter term, where the creditor does not make a commitment to renew the transaction at specified intervals throughout the amortization period.
+	      					</content>
+	      				</paragraph>
+	      				<paragraph marker="iii">
+	      					<content>
+	      						Transactions with a fixed interest rate where one or more of the regular periodic payments may result in an increase in the principal balance (a negative amortization feature).
+	      					</content>
+	      				</paragraph>
+	      			</paragraph>
+	  			<appendixHeader>2(b) Creditor</appendixHeader>
+	      		<paragraph marker="1">
+	      			<title>Creditor</title>
+	      			<content>
+	      				As defined in 12 CFR 226.2, “creditor” includes federally and State-chartered banks, thrifts, and credit unions, as well as non-depository institutions, such as State-licensed lenders. The Official Staff Commentary to 12 CFR 226.2 contains additional guidance on the definition of the term “creditor.” See 12 CFR 226.2, Supp. I.
+	      			</content>
+	      		</paragraph>
+	   			</appendixSection>
+	   		</appendix>
+	   	</content>
+	</part>
+
+</regulation>

--- a/src/table.xsd
+++ b/src/table.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+
+	<include schemaLocation="primitives.xsd"></include>
+
+	<complexType name="Table">
+		<sequence>
+			<choice minOccurs="0" maxOccurs="1">
+				<element name="header" type="tns:TableHeader"></element>
+			</choice>
+			<choice minOccurs="1" maxOccurs="unbounded">
+				<element name="row" type="tns:Row"></element>
+			</choice>
+		</sequence>
+	</complexType>
+	
+	<complexType name="TableHeader">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="columnHeaderRow" type="tns:ColumnHeaderRow"></element>
+		</sequence>
+	</complexType>
+	
+	<complexType name="ColumnHeaderRow">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="column" type="tns:ColumnHeaderEntry"></element>
+		</sequence>
+	</complexType>
+	
+	<complexType name="ColumnHeaderEntry" mixed="true">
+		<attribute name="colspan" type="int"></attribute>
+		<attribute name="rowspan" type="int"></attribute>
+	</complexType>
+	
+	<complexType name="Row">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="cell" type="tns:CellContents"></element>
+		</sequence>
+	</complexType>
+	
+	<complexType name="CellContents" mixed="true">
+		<choice minOccurs="0" maxOccurs="unbounded">
+			<element ref="tns:ref"></element>
+		</choice>
+	</complexType>
+	
+	<element name="column" type="tns:ColumnHeaderEntry"></element>
+	<element name="table" type="tns:Table"></element>
+	
+</schema>

--- a/src/toc.xsd
+++ b/src/toc.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="eregs"
+	xmlns:tns="eregs" 
+	elementFormDefault="qualified">
+	
+	<!-- 
+		The tableOfContents element describes the contents of the element that contains it.
+		It consists of the following elements:
+		1. zero or more tocSecEntry elements, which express a reference to a section of the content.
+		   The tocSecEntry consists of the following elements:
+			a. sectionNum, an integer indicating the section number
+			b. sectionSubject, a string indicating the section title
+		   In addition, the tocSecEntry element supports the following attributes:
+		    a. target, a string indicating the label of the element being referenced
+		2. zero or more tocAppEntry elements, which express a reference to a section of the appendix content.
+		   The tocAppEntry consists of the following elements:
+		    a. zero or one appendixLetter, a string containing the letter of the appendix being referenced
+		    b. appendixSubject, a string containing the subject of the appendix or section being referenced
+		   In addition, the tocAppEntry element supports the following attributes:
+		    a. target, a string indicating the label of the element being referenced
+	 -->
+	
+	<complexType name="TableOfContents">
+		<sequence>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element name="tocSecEntry">
+					<complexType>
+						<sequence>
+							<element name="sectionNum" type="int"></element>
+							<element name="sectionSubject" type="string"></element>
+						</sequence>
+						<attribute name="target" type="string" use="required"></attribute>
+					</complexType>
+				</element>
+			</choice>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element name="tocAppEntry">
+					<complexType>
+						<sequence>
+							<choice minOccurs="0" maxOccurs="1">
+								<element name="appendixLetter" type="string"></element>
+							</choice>
+							<element name="appendixSubject" type="string"></element>
+						</sequence>
+						<attribute name="target" type="string" use="required"></attribute>
+					</complexType>
+				</element>
+			</choice>
+		</sequence>
+	</complexType>
+	
+</schema>


### PR DESCRIPTION
This PR imports the xsd files into the gh-pages branch so they can be served via GitHub pages.

This makes it possible for us to define the schema location in the XML with a URL like http://cfpb.github.io/regulations-schema/src/eregs.xsd.
