### PR TITLE
Fixes for interps

### DIFF
--- a/src/formatting.xsd
+++ b/src/formatting.xsd
@@ -16,8 +16,18 @@
 			</extension>
 		</simpleContent>
 	</complexType>
-	
+
+	<complexType name="Callout">
+        <sequence>
+            <element name="line" minOccurs="1" maxOccurs="unbounded"></element>
+        </sequence>
+        <attribute name="type" type="string" use="required"></attribute>
+    </complexType>
+    
 	<element name="em"></element>
 	<element name="dash"></element>
+	<element name="variable"></element>
+	<element name="subscript"></element>
+	<element name="callout" type="tns:Callout"></element>
 	
 </schema>

--- a/src/interpretation.xsd
+++ b/src/interpretation.xsd
@@ -50,7 +50,15 @@
 	<complexType name="InterpAppSection">
 		<sequence>
 			<choice minOccurs="0" maxOccurs="1">
-				<element name="title" type="string"></element>
+    			<element name="title">
+    				<complexType>
+    					<simpleContent>
+    						<extension base="string">
+    							<attribute name="type" type="tns:titleType"></attribute>
+    						</extension>
+    					</simpleContent>
+    				</complexType>
+    			</element>
 			</choice>
 			<choice maxOccurs="unbounded">
 				<element name="reserved" type="string"></element>
@@ -94,7 +102,15 @@
     <complexType name="InterpParagraph">
     	<sequence>
     		<choice minOccurs="0" maxOccurs="1">
-    			<element name="title" type="string"></element>
+    			<element name="title">
+    				<complexType>
+    					<simpleContent>
+    						<extension base="string">
+    							<attribute name="type" type="tns:titleType"></attribute>
+    						</extension>
+    					</simpleContent>
+    				</complexType>
+    			</element>
     		</choice>
     		<element name="content" type="tns:RegText"></element>
     		<element ref="tns:interpParagraph" minOccurs="0" maxOccurs="unbounded"></element>

--- a/src/interpretation.xsd
+++ b/src/interpretation.xsd
@@ -44,6 +44,7 @@
 		</sequence>
 		<attribute name="sectionNum" type="int" use="optional"></attribute>
     	<attribute name="label" type="string" use="required"></attribute>
+	<attribute name="target" type="string" use="optional"></attribute>
 	</complexType>
 	
 	<complexType name="InterpAppSection">

--- a/src/primitives.xsd
+++ b/src/primitives.xsd
@@ -27,6 +27,8 @@
 			<element ref="tns:dash"></element>
 			<element ref="tns:table"></element>
 			<element ref="tns:analysis"></element>
+			<element ref="tns:callout"></element>
+			<element ref="tns:variable"></element>
 		</choice>
 	</complexType>
 	


### PR DESCRIPTION
This PR adds a couple of minor things to the schema from the formatting layer:
- `callout`, which represents appendix notes and code blocks which are called-out in the UI.
- `variable`, which represents a variable in the regulation
- `subscript`, which represents subscripts

This PR also makes a few minor changes to interpretations:
- Interp sections can also have targets (because they usually apply to a whole section of a regulation).
- All titles in interps are handled the same way titles are elsewhere, and can therefore have the `keyterm` type, etc.

@grapesmoker @hillaryj 
