### PR TITLE
Add optional attributes to analysisSection and subpart

### DIFF
--- a/src/analysis.xsd
+++ b/src/analysis.xsd
@@ -36,7 +36,7 @@
         <element ref="tns:analysisSection"></element>
       </choice>
     </sequence>
-	<attribute name="target" type="string" use="optional"></attribute>
+    <attribute name="target" type="string" use="optional"></attribute>
   </complexType>
 
   <!-- 

--- a/src/analysis.xsd
+++ b/src/analysis.xsd
@@ -36,6 +36,7 @@
         <element ref="tns:analysisSection"></element>
       </choice>
     </sequence>
+	<attribute name="target" type="string" use="optional"></attribute>
   </complexType>
 
   <!-- 

--- a/src/part.xsd
+++ b/src/part.xsd
@@ -90,6 +90,7 @@
     		</choice>
     	</sequence>
     	<attribute name="subpartLetter" type="string"></attribute>
+    	<attribute name="label" type="string" use="optional"></attribute>
     </complexType>
     
     <!-- 


### PR DESCRIPTION
This PR adds an optional `target` attribute to `analysisSection` elements and an optional `label` to `subpart` elements.
