### PR TITLE
Add "moved" operation to changes

### DIFF
--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -53,7 +53,14 @@
        version of a regulation with the given contents. Deletions won't 
        have any content.
 
-       "operation" should be one of "added", "modified", or "deleted".
+       - `operation` should be one of "added", "modified", "deleted", or 
+         "moved".
+       - `parent`, optional for "added" and required for "moved" 
+         operations, should correspond to the new parent label.
+       - `after`, optional for "added" and "moved" operations, should 
+         correspond to the preceding sibling label, if there is one.
+       - `before`, optional for "added" and "moved" operations, should 
+         correspond to the following sibling label, if there is one.
    -->
   <complexType name="Change">
     <choice minOccurs="0" maxOccurs="unbounded">
@@ -73,10 +80,14 @@
           <enumeration value="added"/>
           <enumeration value="modified"/>
           <enumeration value="deleted"/>
+          <enumeration value="moved"/>
         </restriction>
       </simpleType>
     </attribute>
-    <attribute name="label"></attribute>
+    <attribute name="label" type="string"></attribute>
+    <attribute name="parent" type="string" use="optional"></attribute>
+    <attribute name="after" type="string" use="optional"></attribute>
+    <attribute name="before" type="string" use="optional"></attribute>
   </complexType>
 
   <element name="change" type="tns:Change"></element>


### PR DESCRIPTION
This PR adds a `moved` operation option to `change`s. In doing so it also adds the optional attributes:
- `parent`, for the destination parent label (for `moved` and `added` changes)
- `before`, for the preceding sibling label (for `moved` and `added`)
- `after`, for the following sibling label (for `moved` and `added`)

`moved` changes, like `deleted`, are expected to be empty, i.e.:

```
<change operation="moved" label="1234-1" parent="1234-Subpart-B"></change>
```

If a node is moved _and_ modified, that should be two separate changes, `moved` and `modified`.
