### PR TITLE
Allow subparts in notice changes & labels on TOCs

### DIFF
--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -65,6 +65,7 @@
   <complexType name="Change">
     <choice minOccurs="0" maxOccurs="unbounded">
       <element name="reserved" type="string"></element>
+      <element ref="tns:subpart"></element>
       <element ref="tns:section"></element>
       <element ref="tns:paragraph"></element>
       <element ref="tns:analysis"></element>

--- a/src/toc.xsd
+++ b/src/toc.xsd
@@ -73,6 +73,7 @@
 				<element ref="tns:tocInterpEntry"></element>
 			</choice>
 		</sequence>
+    	<attribute name="label" type="string" use="optional"></attribute>
 	</complexType>
 	
 	<element name="tocSecEntry" type="tns:SectionEntry"></element>


### PR DESCRIPTION
This PR adds the subpart element to possible change elements, and labels to tableOfContents elements.
