### PR TITLE
Allow tables of contents in appendix sections

### DIFF
--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -42,7 +42,8 @@
 		The appendixSection type defines a section of an appendix. It consists of the
 		following elements:
 		1. subject, a string containing the section title
-		2. zero or more appendixHeader elements optionally followed by paragraph elements
+		2. either 0 or 1 tableOfContents elements
+		3. zero or more appendixHeader elements optionally followed by paragraph elements
 		
 		In addition the appendixSection element supports the following attributes:
 		1. appendixSecNum, an integer indicating the section number

--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -52,6 +52,9 @@
 	<complexType name="AppendixSection">
     	<sequence>
     		<element name="subject" type="string"></element>
+			<choice minOccurs="0" maxOccurs="1">
+				<element ref="tns:tableOfContents"></element>
+			</choice>
     		<choice maxOccurs="unbounded">
     			<element name="reserved" type="string"></element>
     			<element ref="tns:appendixHeader"></element>


### PR DESCRIPTION
This PR allows for tables of contents in appendix sections. An example of where we would want this is in Regulation X (1024), Appendix MS, MS-3.
