### PR TITLE
Breaking analysis

### DIFF
--- a/src/analysis.xsd
+++ b/src/analysis.xsd
@@ -27,6 +27,10 @@
       1. title, the title of the analysis section
       2. one or more paragraph elements
       3. zero or more other analysisSection elements
+
+      analysisSecton has three possible attributes, target (the label 
+      within the regulation text that it analyzes), notice (the 
+      notice number it originated in), and date (the notice publication date).
    -->
   <complexType name="AnalysisSection">
     <sequence>
@@ -38,6 +42,8 @@
       </choice>
     </sequence>
     <attribute name="target" type="string" use="optional"></attribute>
+    <attribute name="notice" type="string" use="optional"></attribute>
+    <attribute name="date" type="string" use="optional"></attribute>
   </complexType>
 
   <!-- 

--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -42,7 +42,8 @@
 		The appendixSection type defines a section of an appendix. It consists of the
 		following elements:
 		1. subject, a string containing the section title
-		2. zero or more appendixHeader elements optionally followed by paragraph elements
+		2. either 0 or 1 tableOfContents elements
+		3. zero or more appendixHeader elements optionally followed by paragraph elements
 		
 		In addition the appendixSection element supports the following attributes:
 		1. appendixSecNum, an integer indicating the section number

--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -30,9 +30,6 @@
 				<element name="reserved" type="string"></element>
 				<element ref="tns:appendixSection"></element>
 			</choice>
-    		<choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
-    		</choice>
 		</sequence>
 		<attribute name="appendixLetter" type="string" use="required"></attribute>
 		<attribute name="label" type="string" use="required"></attribute>
@@ -60,9 +57,6 @@
     			<element name="reserved" type="string"></element>
     			<element ref="tns:appendixHeader"></element>
     			<element ref="tns:paragraph"></element>
-    		</choice>
-    		<choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
     		</choice>
     	</sequence>
     	<attribute name="appendixSecNum" type="string" use="required"></attribute>

--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -52,6 +52,9 @@
 	<complexType name="AppendixSection">
     	<sequence>
     		<element name="subject" type="string"></element>
+			<choice minOccurs="0" maxOccurs="1">
+				<element ref="tns:tableOfContents"></element>
+			</choice>
     		<choice maxOccurs="unbounded">
     			<element name="reserved" type="string"></element>
     			<element ref="tns:appendixHeader"></element>

--- a/src/eregs.xsd
+++ b/src/eregs.xsd
@@ -15,6 +15,7 @@
 	<include schemaLocation="toc.xsd"></include>
 	<include schemaLocation="part.xsd"></include>
 	<include schemaLocation="notices.xsd"></include>
+	<include schemaLocation="analysis.xsd"></include>
 	
 	<!-- 
 		The regulation consists of three elements:
@@ -29,6 +30,7 @@
     		<element name="preamble" type="tns:Preamble"></element>
 	    	<choice minOccurs="1" maxOccurs="unbounded">
 	    		<element ref="tns:part"></element>
+    			<element ref="tns:analysis"></element>
 	    	</choice>
     	</sequence>
     </complexType>

--- a/src/interpretation.xsd
+++ b/src/interpretation.xsd
@@ -38,9 +38,6 @@
 				<element name="reserved" type="string"></element>
     			<element ref="tns:interpParagraph"></element>
 			</choice>
-            <choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
-            </choice>
 		</sequence>
 		<attribute name="sectionNum" type="int" use="optional"></attribute>
     	<attribute name="label" type="string" use="required"></attribute>
@@ -64,9 +61,6 @@
 				<element name="reserved" type="string"></element>
     			<element ref="tns:interpParagraph"></element>
 			</choice>
-            <choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
-            </choice>
 		</sequence>
 		<attribute name="appendixSecNum" type="int" use="required"></attribute>
     	<attribute name="label" type="string" use="required"></attribute>
@@ -78,7 +72,6 @@
 			<choice minOccurs="0" maxOccurs="unbounded">
 				<element ref="tns:interpAppSection"></element>
 				<element ref="tns:interpParagraph"></element>
-    			<element ref="tns:analysis"></element>
 			</choice>
 		</sequence>
 		<attribute name="appendixLetter" type="string" use="required"></attribute>
@@ -92,9 +85,6 @@
     		</choice>
     		<choice minOccurs="0" maxOccurs="unbounded">
                 <element ref="tns:interpAppendix"></element>
-    		</choice>
-    		<choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
     		</choice>
     	</sequence>
     </complexType>
@@ -114,9 +104,6 @@
     		</choice>
     		<element name="content" type="tns:RegText"></element>
     		<element ref="tns:interpParagraph" minOccurs="0" maxOccurs="unbounded"></element>
-            <choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
-            </choice>
     	</sequence>
 		<attribute name="marker" type="string" use="optional"></attribute>
 		<attribute name="label" type="string" use="required"></attribute>

--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -8,6 +8,7 @@
   <include schemaLocation="preamble.xsd"></include>
   <include schemaLocation="toc.xsd"></include>
   <include schemaLocation="part.xsd"></include>
+  <include schemaLocation="analysis.xsd"></include>
 
   <!-- 
        Notices include the same sorts of content as regulations do,
@@ -16,6 +17,9 @@
        
       All the notice metadata is contained within the preamble, which 
       is identical to the regulation preamble.
+
+      Any analysis that is provided with the notice will be contained 
+      within a top-level child of the notice.
   -->
   <complexType name="Notice">
     <sequence>
@@ -23,6 +27,7 @@
       <element ref="tns:preamble"></element>
       <choice minOccurs="0" maxOccurs="1">
         <element ref="tns:changeset"></element>
+    	<element ref="tns:analysis"></element>
       </choice>
     </sequence>
   </complexType>
@@ -69,6 +74,7 @@
       <element ref="tns:section"></element>
       <element ref="tns:paragraph"></element>
       <element ref="tns:analysis"></element>
+      <element ref="tns:analysisSection"></element>
       <element ref="tns:appendix"></element>
       <element ref="tns:appendixSection"></element>
       <element ref="tns:interpParagraph"></element>

--- a/src/part.xsd
+++ b/src/part.xsd
@@ -26,7 +26,6 @@
     		<choice maxOccurs="unbounded">
     			<element name="reserved" type="string"></element>
     			<element name="paragraph" type="tns:Paragraph"></element>
-    			<element ref="tns:analysis"></element>
     		</choice>
     	</sequence>
     	<attribute name="sectionNum" type="int" use="required"></attribute>

--- a/src/primitives.xsd
+++ b/src/primitives.xsd
@@ -6,7 +6,6 @@
 	
 	<include schemaLocation="table.xsd"></include>
 	<include schemaLocation="formatting.xsd"></include>
-	<include schemaLocation="analysis.xsd"></include>
 	
 	<!-- 
 		This file represents the primitives that are allowed in the RegsML.
@@ -26,7 +25,6 @@
 			<element ref="tns:graphic"></element>
 			<element ref="tns:dash"></element>
 			<element ref="tns:table"></element>
-			<element ref="tns:analysis"></element>
 			<element ref="tns:callout"></element>
 			<element ref="tns:variable"></element>
 		</choice>
@@ -71,9 +69,6 @@
     		</choice>
     		<element name="content" type="tns:RegText"></element>
     		<element ref="tns:paragraph" minOccurs="0" maxOccurs="unbounded"></element>
-    		<choice minOccurs="0" maxOccurs="unbounded">
-    			<element ref="tns:analysis"></element>
-    		</choice>
     	</sequence>
 		<attribute name="marker" type="string" use="required"></attribute>
 		<attribute name="label" type="string"></attribute>


### PR DESCRIPTION
This PR removes `analysis` from its contextual locations and places it at the end of the documents. 

`analysis` is now a top-level child of `regulation` and `notice`. 

A new `target` attribute specifies the target label for first-child `analysisSection` elements. 

`analysisSection` now has a `notice` and `date` attribute, specifying the notice document number it originated in and the publication date of that notice. This is necessary for generating the analysis reference layer.
