### PR TITLE
Fix notice validation

### DIFF
--- a/src/appendix.xsd
+++ b/src/appendix.xsd
@@ -72,7 +72,6 @@
 	</simpleType>
 	
 	<element name="appendix" type="tns:Appendix"></element>
-	<element name="tableOfContents" type="tns:TableOfContents"></element>
 	<element name="appendixSection" type="tns:AppendixSection"></element>
     <element name="appendixHeader" type="tns:AppendixHeader"></element>
 	

--- a/src/interpretation.xsd
+++ b/src/interpretation.xsd
@@ -11,7 +11,7 @@
 	<complexType name="Interpretations">
 		<sequence>
 			<choice minOccurs="0" maxOccurs="1">
-    			<element name="tableOfContents" type="tns:TableOfContents"></element>
+    			<element ref="tns:tableOfContents"></element>
     		</choice>
 			<element name="title" type="string"></element>
 			<sequence>

--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -91,7 +91,7 @@
           <enumeration value="modified"/>
           <enumeration value="deleted"/>
           <enumeration value="moved"/>
-          <enumeration value="changeTermTarget"/>
+          <enumeration value="changeTarget"/>
         </restriction>
       </simpleType>
     </attribute>

--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -69,7 +69,7 @@
        - `before`, optional for "added" and "moved" operations, should 
          correspond to the following sibling label, if there is one.
    -->
-  <complexType name="Change">
+  <complexType name="Change" mixed="true">
     <choice minOccurs="0" maxOccurs="unbounded">
       <element name="reserved" type="string"></element>
       <element ref="tns:subpart"></element>
@@ -83,6 +83,9 @@
       <element ref="tns:interpretations"></element>
       <element ref="tns:interpSection"></element>
       <element ref="tns:tableOfContents"></element>
+      <element name="title" type="string"></element>
+      <element name="subject" type="string"></element>
+      <element name="content" type="tns:RegText"></element>
     </choice>
     <attribute name="operation">
       <simpleType>

--- a/src/part.xsd
+++ b/src/part.xsd
@@ -82,7 +82,7 @@
     			<element name="title" type="string"></element>
     		</choice>
     		<choice minOccurs="0" maxOccurs="1">
-    			<element name="tableOfContents" type="tns:TableOfContents"></element>
+    			<element ref="tns:tableOfContents"></element>
     		</choice>
     		<choice minOccurs="1" maxOccurs="unbounded">
     			<element name="content" type="tns:PartContents"></element>
@@ -105,7 +105,7 @@
 	<complexType name="Part">	
 		<sequence>
 			<choice minOccurs="0" maxOccurs="1">
-				<element name="tableOfContents" type="tns:TableOfContents"></element>
+				<element ref="tns:tableOfContents"></element>
 			</choice>
 			<element name="content">
 				<complexType>

--- a/src/toc.xsd
+++ b/src/toc.xsd
@@ -81,5 +81,6 @@
 	<element name="tocAppEntry" type="tns:AppendixEntry"></element>
 	<element name="tocSubpartEntry" type="tns:SubpartEntry"></element>
 	<element name="tocInterpEntry" type="tns:InterpEntry"></element>
-	
+    <element name="tableOfContents" type="tns:TableOfContents"></element>
+    
 </schema>


### PR DESCRIPTION
This PR updates the notice schema now that we’re validating notices in apply-through in regulations-xml-parser. It makes three basic changes:
1. Add all the elements we’re currently using in `change` to the schema
2. Renames `changeTermTarget` to `changeTarget` for consistency with the data and regulations-xml-parser
3. Makes `tableOfContents` a global element and changes all the locations its used to use that global element (so that `tableOfContents` works with the existing notice schema).
