### PR TITLE
Gh pages add left eff date

### DIFF
--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -53,6 +53,9 @@
     </sequence>
     <attribute name="leftDocumentNumber" type="string"></attribute>
     <attribute name="rightDocumentNumber" type="string"></attribute>
+    <attribute name="leftEffectiveDate" type="date"></attribute>
+    <attribute name="rightEffectiveDate" type="date"></attribute>
+    <attribute name="order" type="integer" use="optional"></attribute>
   </complexType>
 
   <!-- 

--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -52,6 +52,7 @@
       </choice>
     </sequence>
     <attribute name="leftDocumentNumber" type="string"></attribute>
+    <attribute name="rightDocumentNumber" type="string"></attribute>
     <attribute name="leftEffectiveDate" type="date"></attribute>
     <attribute name="order" type="integer" use="optional"></attribute>
   </complexType>

--- a/src/notices.xsd
+++ b/src/notices.xsd
@@ -52,9 +52,7 @@
       </choice>
     </sequence>
     <attribute name="leftDocumentNumber" type="string"></attribute>
-    <attribute name="rightDocumentNumber" type="string"></attribute>
     <attribute name="leftEffectiveDate" type="date"></attribute>
-    <attribute name="rightEffectiveDate" type="date"></attribute>
     <attribute name="order" type="integer" use="optional"></attribute>
   </complexType>
 


### PR DESCRIPTION
This PR adds the `leftEffectiveDate` property to a changeset; this allows for a proper sequencing of notices. Sometimes a single notice will contain multiple effective dates, which means we split the changeset into two files. Each of those files will have the same `documentNumber` but different `effectiveDate`s. Therefore, the next notice needs to know which of the effective dates it should apply to. In the past, this was handled by mashing the document number and the effective date into a single value, e.g. `2013-22752_20140110` but this is a bad solution because the two fields are semantically distinct and it messes up the URL scheme. This minor change to the schema allows for a `leftEffectiveDate` property so we can specify the effective date of the previous schema. This change will be accompanied by a corresponding change to `regulations-xml-parser` that will take advantage of this information for sequencing purposes.