### PR TITLE
Fixing typo in tocHeaderEntry definition

### DIFF
--- a/src/toc.xsd
+++ b/src/toc.xsd
@@ -83,7 +83,7 @@
   <element name="tocAppEntry" type="tns:AppendixEntry"></element>
   <element name="tocSubpartEntry" type="tns:SubpartEntry"></element>
   <element name="tocInterpEntry" type="tns:InterpEntry"></element>
-  <element name="tocHeaderentry" type="tns:tocHeaderEntry"></element>
+  <element name="tocHeaderEntry" type="tns:HeaderEntry"></element>
   <element name="tableOfContents" type="tns:TableOfContents"></element>
   
 </schema>


### PR DESCRIPTION
This typo (`tocHeaderentry` -> `tocHeaderEntry`) was fixed in the gh-pages branch in this commit:

https://github.com/cfpb/regulations-schema/commit/d1b0a41fe50884c6c7a6eaef73fe1325bf0310df

but this didn't get carried over to the master branch for some reason. This is needed to properly validate RegML.